### PR TITLE
fix:创建项目中选择zap,build时出现 cannot call non-function di.ZapOutput{...} (type di.ZapOutput)

### DIFF
--- a/commands/new.go
+++ b/commands/new.go
@@ -218,7 +218,7 @@ func (t *NewCommand) NewProject(name, selectType, useDotenv, useConf, selectLog,
 		if err := logic.ReplaceAll(dest, `logger := di.Logrus`, `logger := di.Zap`); err != nil {
 			panic(errors.New("Replace failed"))
 		}
-		if err := logic.ReplaceAll(dest, `Output: logger.Writer()`, `Output: &di.ZapOutput{Logger: logger}`); err != nil {
+		if err := logic.ReplaceAll(dest, `Output: logger.Writer\(\)`, `Output: &di.ZapOutput{Logger: logger}`); err != nil {
 			panic(errors.New("Replace failed"))
 		}
 		_ = os.Remove(fmt.Sprintf("%s/di/logrus.go", dest))


### PR DESCRIPTION
创建项目中选择zap,build时出现 cannot call non-function di.ZapOutput{...} (type di.ZapOutput)